### PR TITLE
カレンダータブを確定版に変更

### DIFF
--- a/calendar/index.html
+++ b/calendar/index.html
@@ -15,7 +15,7 @@
         <div style="text-align: center; margin-bottom: 40px">
           <h1 class="reveal" style="color: var(--secondary); font-size: 2.8rem; margin-bottom: 15px">Community Calendar</h1>
           <p class="reveal" style="color: var(--text-light); font-size: 1.1rem; max-width: 760px; margin: 0 auto">
-            定例のオンライン勉強会・部門ミーティング・イベントなど、SnowVillage 全体のスケジュールを共有しています。
+            イベント・定例のオンライン勉強会・部門ミーティングなど、SnowVillage 全体のスケジュールを共有しています。
           </p>
         </div>
 
@@ -29,17 +29,18 @@
           <p>新しい会を立ち上げる際は、まずこのカレンダーで他イベントとの日程重複をご確認ください。SnowVillage の定例予定とは別日にすることで、参加者が集まりやすくなります。</p>
         </div>
 
-        <div class="calendar-legend reveal">
-          <strong>凡例</strong>
-          <ul>
-            <li><span class="legend-icon">🌐</span>オンラインイベント（地球儀／ネットワーク）</li>
-            <li><span class="legend-icon">🎪</span>オフライン・対面イベント（サーカス）</li>
-          </ul>
-        </div>
-
         <div class="calendar-wrapper reveal" aria-label="当月分の SnowVillage カレンダー">
           <iframe src="https://calendar.google.com/calendar/u/0/embed?src=295ef847e514cf67debce604f99909d12925a5d7b023e44a0d13c668a1e47137@group.calendar.google.com&ctz=Asia/Tokyo" style="border-width: 0" frameborder="0" scrolling="no"></iframe>
         </div>
+        
+        <div class="calendar-legend reveal">
+          <strong>凡例</strong>
+          <ul>
+            <li><span class="legend-icon">🌐</span>オンラインイベント</li>
+            <li><span class="legend-icon">🎪</span>オフライン・対面イベント</li>
+          </ul>
+        </div>
+
         <p class="reveal" style="text-align: center; color: var(--text-light); font-size: 0.9rem; margin-top: 16px">※ 上記は参考表示です。最新・全体ビューは Google カレンダーでご確認ください。</p>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- ページ冒頭の説明文を「イベント・定例のオンライン勉強会・部門ミーティングなど〜」に微修正
- カレンダー埋め込み（月表示 iframe）を凡例より上に移動
- 凡例のアイコン脇の補足（「地球儀／ネットワーク」「サーカス」）を削除

## Test plan
- [ ] /calendar/ で上から CTA → 主催者注意書き → カレンダー埋め込み → 凡例 の順で表示
- [ ] 凡例のオンライン/オフライン表記が簡潔になっている