### PR TITLE
歩き方ページからオフィス利用ガイド節と古い注意書きを削除

### DIFF
--- a/guide/index.html
+++ b/guide/index.html
@@ -32,7 +32,6 @@
           <ol>
             <li><a href="#slack">Slack の歩き方</a></li>
             <li><a href="#event-plan">イベント・勉強会を企画・運営したい</a></li>
-            <li><a href="#office">Snowflake オフィスの利用ルール・ガイド</a></li>
           </ol>
         </nav>
 
@@ -46,11 +45,6 @@
           <p>
             <a href="../join/" class="btn">コミュニティ行動規範を読む</a>
           </p>
-          <div class="callout warning">
-            <div class="content">
-              <p>当コミュニティの Slack は無料版のため、<strong>3ヶ月でメッセージが消えてしまいます</strong>。解決した議論や有用な知見は、ブログ記事など別媒体にもアウトプットしておくことをおすすめします。</p>
-            </div>
-          </div>
 
           <h3>チャンネルの作成・削除ルール</h3>
           <p>
@@ -94,62 +88,6 @@
           <p>
             日程の重複を避けたい場合は <a href="../calendar/" style="color: var(--primary); font-weight: 600">カレンダー</a> で既存イベントを確認できます。企画の前に一度チェックしておくとスムーズです。
           </p>
-        </section>
-
-        <section class="guide-section reveal" id="office">
-          <h2>Snowflake オフィスの利用ルール・ガイド</h2>
-
-          <h3>利用ルール</h3>
-          <p>
-            Snowflake 様よりコミュニティとしてのオフィス利用をご快諾いただいています。一方で頻繁な利用は Snowflake 社の負担にもなるため、<strong>1ヶ月に1回程度</strong>を上限の目安としてお借りしています。
-          </p>
-          <p>
-            Snowflake オフィスでイベントを開催したい場合は、<span class="channel-tag">#mayors</span> チャンネルで一度ご相談ください。利用可能な月が共有されたら、具体的な日程を Snowflake 社・イベント幹事間で決めていきます。確定次第、<span class="channel-tag">#mayors</span> チャンネルへの共有もお願いします。
-          </p>
-          <p>
-            ケータリングについても、人数感や目的に応じて相談可能です。まずは Mayors に声をかけて、一緒に Snowflake へ相談していきましょう。
-          </p>
-
-          <h3>オフィス利用ガイド</h3>
-          <p>
-            Snowflake オフィスには Lodge（食堂）やセミナールーム（3〜40名収容）、カフェスペースなどのイベントブースがあります。大半のイベントは Lodge を利用することになるため、その際のガイドを記載します。
-          </p>
-
-          <h4>Snowflake とのやり取り</h4>
-          <p>
-            日程が確定したら、1週間前を目処に参加者の氏名・メールアドレスを Snowflake 社に連携します。直前まで募集を続けたい場合は事前にすり合わせをしておきましょう。
-          </p>
-          <p>
-            TECH PLAY などでの募集時に、<strong>参加者の氏名とメールアドレスを必ず収集する</strong>ことを忘れないでください。Snowflake からの入館登録メールが参加者に届いたら、登録を促しましょう。
-          </p>
-          <div class="callout tip">
-            <div class="content">
-              <span class="tip-label">Tips: セキュリティゲート</span>
-              <p>24F のセキュリティゲートで QR コードをかざしてエレベータに乗り、Snowflake オフィスに入館します。QR コードはイベントごとに払い出されるため、TECH PLAY の参加者限定ページなどに入館方法と合わせて掲載しておくとスムーズです。</p>
-            </div>
-          </div>
-
-          <h4>中央モニターの利用方法</h4>
-          <p>
-            画面投影機自体が Zoom クライアント・Google Meet クライアントになっており、投影機から Zoom URL を発行して登壇者が Join することも、運営側が用意した URL に投影機を Join させることもできます。オンライン配信の要件に応じて使い分けてください。
-          </p>
-
-          <h4>オンライン配信について</h4>
-          <p>
-            ハイブリッド形式の場合は、配信用ミーティングツールの準備と、SnowVillage YouTube チャンネルへの配信設定が必要です。<span class="channel-tag">#mayors</span> チャンネルで事前にご相談ください。
-          </p>
-          <p>
-            ミーティングツールは運営側で準備いただくか、Snowflake に依頼するかのいずれも可能ですが、Snowflake 側のオンライン配信リソースは限られています。基本はコミュニティ運営側で対応する前提でお願いします。YouTube 配信設定は <span class="channel-tag">#mayors</span> がサポートします。
-          </p>
-          <div class="callout tip">
-            <div class="content">
-              <span class="tip-label">その他の Tips</span>
-              <ul style="margin-left: 20px; color: var(--text)">
-                <li>マイク・BGM 制御装置などは、画面投影機の下部にあります。</li>
-                <li>移動モニターを利用したい場合は、事前に Snowflake 社内での調整が必要です。早めに相談しましょう。</li>
-              </ul>
-            </div>
-          </div>
         </section>
       </article>
     </main>


### PR DESCRIPTION
- "Snowflake オフィスの利用ルール・ガイド" セクション (#office) を削除
- "利用ガイドラインを確認する" の Slack 3ヶ月で消える注意書きを削除
- 付随修正: 削除済みセクションを参照していた目次の #office リンクを除去