### PR TITLE
Provisional setup of Mayor member slot and minor display fixes

### DIFF
--- a/about/aboutData.js
+++ b/about/aboutData.js
@@ -5,6 +5,15 @@
 // 🌟 Mayors（意思決定権を持つ運営中核メンバー）
 const mayorsData = [
   {
+    name: "K T",
+    role: "None",
+    desc: "Japan Community Lead Canva<br>None",
+    departments: [""],
+    photo: "../images/organizers/SnowVillageLogo-white.png",
+    xUrl: "None",
+    linkedInUrl: "None",
+  },
+  {
     name: "Yuya Matsubara",
     role: "Snowflake DataSuperheros 2026 & Snowflake Squad",
     desc: "Principal Data Engineer at NTT DOCOMO, Inc.<br />Slackでなんかうるさいやつです!",
@@ -58,6 +67,33 @@ const mayorsData = [
     xUrl: "https://x.com/suzupappa",
     linkedInUrl: "https://www.linkedin.com/in/suzupappa",
   },
+  {
+    name: "Akira Sakatoku",
+    role: "None",
+    desc: "Core Staff KDDI Corporation<br>None",
+    departments: ["Brand","GROWTH"],
+    photo: "../images/organizers/SnowVillageLogo-white.png",
+    xUrl: "None",
+    linkedInUrl: "None",
+  },
+  {
+    name: "pei 0804",
+    role: "None",
+    desc: "Vice President of Data CARTA ZERO<br>None",
+    departments: [],
+    photo: "../images/organizers/SnowVillageLogo-white.png",
+    xUrl: "None",
+    linkedInUrl: "None",
+  },
+  {
+    name: "Toru Hiyama",
+    role: "None",
+    desc: "SimpleForm, Inc<br>None",
+    departments: [""],
+    photo: "../images/organizers/SnowVillageLogo-white.png",
+    xUrl: "None",
+    linkedInUrl: "None",
+  }
 ];
 
 // 🌟 Neighbors（年次募集に応じてくれた、役職はないが頼れる貢献メンバー）

--- a/about/departments/index.html
+++ b/about/departments/index.html
@@ -70,7 +70,7 @@
       </div>
 
       <section class="reveal" style="border-top: 1px solid #eee; margin-top: 80px; padding-top: 60px">
-        <h2 style="text-align: center; color: var(--secondary); margin-bottom: 10px">Supporters & Sponsors</h2>
+        <h2 style="text-align: center; color: var(--secondary); margin-bottom: 10px">Sponsor</h2>
         <p style="text-align: center; color: var(--text-light); max-width: 700px; margin: 0 auto 40px">
           部門活動・サイト運営に協賛していただいている個人・企業様方。
         </p>

--- a/about/departments/index.html
+++ b/about/departments/index.html
@@ -72,7 +72,7 @@
       <section class="reveal" style="border-top: 1px solid #eee; margin-top: 80px; padding-top: 60px">
         <h2 style="text-align: center; color: var(--secondary); margin-bottom: 10px">Supporters & Sponsors</h2>
         <p style="text-align: center; color: var(--text-light); max-width: 700px; margin: 0 auto 40px">
-          部門活動を個人の貢献・企業の協賛で支えてくださっている皆さんです。
+          部門活動・サイト運営に協賛していただいている個人・企業様方。
         </p>
         <div id="sponsors-grid" class="grid" style="grid-template-columns: repeat(auto-fit, minmax(220px, 1fr))"></div>
       </section>

--- a/css/about.css
+++ b/css/about.css
@@ -50,7 +50,7 @@
 
 /* --- スポンサーロゴ --- */
 .sponsor-card { display: flex; flex-direction: column; justify-content: center; align-items: center; padding: 40px 20px; }
-.sponsor-logo { max-width: 100%; height: auto; max-height: 60px; margin-bottom: 15px; filter: grayscale(100%); opacity: 0.7; transition: all 0.4s ease; }
+.sponsor-logo { max-width: 100%; height: auto; max-height: 60px; margin-bottom: 15px; filter: grayscale(0%); opacity: 0.7; transition: all 0.4s ease; }
 .sponsor-card:hover .sponsor-logo { filter: grayscale(0%); opacity: 1; transform: scale(1.1); }
 
 /* --- css/about.css の後半部分を修正 --- */

--- a/newsData.js
+++ b/newsData.js
@@ -1,54 +1,17 @@
 // --- 🌟 お知らせデータ管理 (newsData.js) ---
 const newsData = [
     {
-        date: "2026.XX.XX",
+        date: "2026.04.22",
         text: "SnowVillage運営体制についてのお知らせ",
         link: "events/", 
         isExternal: false
     },
     {
-        date: "2026.XX.XX",
+        date: "2026.04.22",
         text: "SnowVillage公式サイトをリニューアルオープンしました！",
         link: "https://snowvillage.cloud/", // events/とかでも良い
         isExternal: true //　内部の場合は false
-    },
-    {
-        date: "2026.XX.XX",
-        text: "sample",
-        link: "events/", 
-        isExternal: false
-    },
-    {
-        date: "2026.XX.XX",
-        text: "sample",
-        link: "events/", 
-        isExternal: false
-    },
-    {
-        date: "2026.XX.XX",
-        text: "sample",
-        link: "events/", 
-        isExternal: false
-    },
-    {
-        date: "2026.XX.XX",
-        text: "sample",
-        link: "events/", 
-        isExternal: false
-    },
-    {
-        date: "2026.XX.XX",
-        text: "sample",
-        link: "events/", 
-        isExternal: false
-    },
-    {
-        date: "2026.XX.XX",
-        text: "sample",
-        link: "events/", 
-        isExternal: false
     }
-
     /* 新しいニュースを追加する場合は、ここにオブジェクトを足していくだけです
     {
         date: "2026.04.01",


### PR DESCRIPTION
### 変更内容
・Mayors 表示ページにおける未PullReqメンバーの仮設定（名前及び所属情報）の実施
　→ 所属情報は https://usergroups.snowflake.com/snowvillage/　 より流用
・他表示の軽微な修正
　→ newsにおけるサンプルレコードの削除　他
