### PR TITLE
Slack 参加導線を Snowflake 公式ユーザーグループページへ切替

### DIFF
--- a/guide/index.html
+++ b/guide/index.html
@@ -43,7 +43,7 @@
             行動規範や運用管理、免責事項などを記載した利用ガイドラインがあります。内容を正しく守ってコミュニティ活動を円滑にするとともに、Slack チャンネルを適切に活用していきましょう。
           </p>
           <p>
-            <a href="../join/" class="btn">コミュニティ行動規範を読む</a>
+            <a href="https://usergroups.snowflake.com/snowvillage/" target="_blank" rel="noopener noreferrer" class="btn">コミュニティ行動規範を読む</a>
           </p>
 
           <h3>チャンネルの作成・削除ルール</h3>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
           </p>
           <div class="hero-ctas">
             <a href="events/" class="btn">最新イベントを見る</a>
-            <a href="join/" class="btn btn-ghost">Slack に参加</a>
+            <a href="https://usergroups.snowflake.com/snowvillage/" target="_blank" rel="noopener noreferrer" class="btn btn-ghost">Slack に参加</a>
           </div>
         </div>
       </div>
@@ -89,7 +89,7 @@
       <section class="home-ctas">
         <div class="cta-card reveal">
           <h2>コミュニティに参加しませんか？</h2>
-          <a href="join/" class="btn">Slack コミュニティに参加 (無料)</a>
+          <a href="https://usergroups.snowflake.com/snowvillage/" target="_blank" rel="noopener noreferrer" class="btn">Slack コミュニティに参加 (無料)</a>
           <p>公式 Slack では、日々の Q&amp;A や雑談が活発に行われています。</p>
         </div>
 

--- a/join/index.html
+++ b/join/index.html
@@ -3,94 +3,31 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Slackに参加 - SnowVillage</title>
-    <link rel="stylesheet" href="../css/common.css" />
-    <link rel="stylesheet" href="../css/join.css" />
+    <meta http-equiv="refresh" content="0; url=https://usergroups.snowflake.com/snowvillage/" />
+    <link rel="canonical" href="https://usergroups.snowflake.com/snowvillage/" />
+    <title>Slack に参加 - SnowVillage</title>
     <link rel="stylesheet" href="../style.css" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;800&display=swap" rel="stylesheet" />
-  <style>
-      #nav-slider {
-        display: none !important;
-        opacity: 0 !important;
-        visibility: hidden !important;
-        width: 0 !important;
-      }
-    </style>
   </head>
   <body>
     <div id="header-container"></div>
 
-    <main class="container" style="padding-top: 150px; padding-bottom: 100px">
-      <section class="join-section">
-        <div style="text-align: center; margin-bottom: 40px">
-          <h2 class="reveal" style="margin-bottom: 10px">Join Our Slack Community</h2>
-          <p class="reveal" style="color: var(--text-light); font-size: 1.1rem">参加する前に、私たちのコミュニティ行動規範（Code of Conduct）をご一読ください。</p>
-        </div>
-
-        <div class="rules-box reveal">
-          <h3>コミュニティ行動規範</h3>
-          <p>SnowVillage は、誰もが歓迎され、安心して学べる場を目指しています。すべての参加者は、以下の規約を遵守することに同意するものとします。</p>
-
-          <div class="rule-item">
-            <h4>オープンなコミュニケーション</h4>
-            <p>参加するすべてのメンバーがオープンにコミュニケーションし、長くいる人も新しく入ってきた人も参加したいと思えばいつでも歓迎できる風土にしましょう。また、コミュニケーションを円滑にするためお名前は個人が識別できるもの（本名、またはソーシャルなどで対外的に使用しているものなど）を設定し、アイコンの設定もできる限りお願いします。</p>
-          </div>
-
-          <div class="rule-item">
-            <h4>積極的に発信</h4>
-            <p>
-              コミュニティメンバーは有志で情報共有や質問の回答をしています。投稿の際はお互いの敬意を忘れず、情報提供をしてくれるメンバーに対して、常に感謝の気持ちやアクションをすることを忘れないようにしましょう。そしてコミュニティで学んだことを自分自身も発信していくようにしましょう。アウトプットすることは自身の成長にもつながります。決して難しいことを発信しなくてはと気負う必要はありません。質問や議題の提供、初心者向けのコンテンツも素晴らしい発信の一つです！
-            </p>
-          </div>
-
-          <div class="rule-item">
-            <h4>建設的な交流</h4>
-            <p>異なる意見は素晴らしいものとして受け止め、建設的に議論しましょう。なお、誹謗中傷、わいせつな言動、人種・性別・性的指向・身体的特徴・政治・宗教などに関する表現や差別は一切容認しません。</p>
-          </div>
-
-          <div class="rule-item">
-            <h4>コミュニティにとって役立つことを考える</h4>
-            <p>Snowflakeのユーザーが役立つと感じるコンテンツを発信してください。Snowflakeはプラットフォームですから、Snowflakeの上に構築された自社プロダクトの紹介や、エコシステムとの連携に関しての議題もウェルカムですが、明らかにSnowflakeのコミュニティと関係のない宣伝行為や採用活動などはご遠慮ください。</p>
-          </div>
-
-          <div class="rule-item">
-            <h4>データを大切に</h4>
-            <p>Snowflakeはデータを大切にする企業です。所属するコミュニティのみなさんもデータの取り扱いに注意して投稿してください。特に、公開したくない自身のプライバシーに関わる情報、他人の個人情報、機密情報などの機微な情報を投稿しないでください。</p>
-          </div>
-
-          <div class="rule-item" style="margin-top: 40px; padding-top: 20px; border-top: 1px dashed #cbd5e0; text-align: center">
-            <p style="font-weight: 600; font-size: 1rem; color: var(--secondary)">
-              <a href="https://community.snowflake.com/s/article/The-Snowflake-Lodge-Code-of-Conduct" target="_blank" rel="noopener noreferrer" style="color: var(--primary); text-decoration: none">The Snowflake Community Code of Conduct</a>
-              <br />ならびに<br />
-              <a href="https://www.snowflake.com/en/legal/other/community-terms-of-service/" target="_blank" rel="noopener noreferrer" style="color: var(--primary); text-decoration: none">Snowflake Community Terms of Service</a>
-              <br />を遵守してください。
-            </p>
-          </div>
-        </div>
-
-        <div class="agreement-area reveal">
-          <label class="checkbox-container">
-            <input type="checkbox" id="agree-checkbox" />
-            <span class="checkmark"></span>
-            <span class="agreement-text">上記のコミュニティ行動規範に同意し、遵守します。</span>
-          </label>
-
-          <div style="margin-top: 30px; text-align: center">
-            <a href="https://usergroups.snowflake.com/snowvillage/" target="_blank" rel="noopener noreferrer" id="slack-join-btn" class="btn btn-slack disabled"> 規約に同意して Slack に参加する </a>
-          </div>
-        </div>
-      </section>
+    <main class="container" style="padding-top: 200px; padding-bottom: 120px; text-align: center">
+      <h1 style="color: var(--secondary); font-size: 2rem; margin-bottom: 20px">Slack 参加ページへ移動します</h1>
+      <p style="color: var(--text-light); line-height: 1.8; margin-bottom: 32px">
+        SnowVillage への Slack 参加は Snowflake 公式のユーザーグループページからご登録いただけます。<br />
+        自動で画面が切り替わらない場合は下のボタンをタップしてください。
+      </p>
+      <a href="https://usergroups.snowflake.com/snowvillage/" class="btn" target="_blank" rel="noopener noreferrer">SnowVillage 参加ページを開く</a>
     </main>
 
     <div id="footer-container"></div>
 
     <script src="../script.js"></script>
     <script>
-      // 🌟 JSを使ってヘッダーとフッターを描画
-      if (typeof renderHeader === "function") {
-        renderHeader("..", "");
-        renderFooter("..");
-      }
+      renderHeader("..", "join");
+      renderFooter();
+      window.location.replace("https://usergroups.snowflake.com/snowvillage/");
     </script>
-  </body class="join-page">
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -11,20 +11,6 @@ document.addEventListener("DOMContentLoaded", () => {
   // スクロールフェードイン制御の開始（各ページで描画されたカードも監視対象になる）
   initScrollReveal();
 
-  // 3. 規約同意チェックボックスの制御 (joinページ用)
-  const agreeCheckbox = document.getElementById("agree-checkbox");
-  const slackJoinBtn = document.getElementById("slack-join-btn");
-
-  if (agreeCheckbox && slackJoinBtn) {
-    agreeCheckbox.addEventListener("change", (e) => {
-      if (e.target.checked) {
-        slackJoinBtn.classList.remove("disabled");
-      } else {
-        slackJoinBtn.classList.add("disabled");
-      }
-    });
-  }
-
   // ==========================================================================
   // 🌟 追加：スクロールプログレスバーの生成と制御
   // ==========================================================================
@@ -160,7 +146,7 @@ const renderHeader = (pathToRoot, activeMenu) => {
             ${logoHtml}
             <ul class="nav-links">
                 ${navItemsHtml}
-                <li><a href="${pathToRoot}/join/" class="btn ${activeMenu === "join" ? "active" : ""}">Slackに参加</a></li>
+                <li><a href="https://usergroups.snowflake.com/snowvillage/" target="_blank" rel="noopener noreferrer" class="btn">Slackに参加</a></li>
                 <li id="nav-slider"></li>
             </ul>
             <div class="burger">


### PR DESCRIPTION
- ヘッダーナビ / HOME hero / HOME CTA / 歩き方の CoC リンクを https://usergroups.snowflake.com/snowvillage/ への直リンクに変更 (target=_blank, rel=noopener noreferrer)
- /join/ 自体はブックマーク等のフォールバック用に残し、 meta refresh + JS で同URLへリダイレクトする薄いページに置換
- 旧 /join/ の規約同意チェックボックス用 JS を削除