### PR TITLE
pei0804 を歴代の貢献者ページへ移行

### DIFF
--- a/about/aboutData.js
+++ b/about/aboutData.js
@@ -77,15 +77,6 @@ const mayorsData = [
     linkedInUrl: "None",
   },
   {
-    name: "pei 0804",
-    role: "None",
-    desc: "Vice President of Data CARTA ZERO<br>None",
-    departments: [],
-    photo: "../images/organizers/SnowVillageLogo-white.png",
-    xUrl: "None",
-    linkedInUrl: "None",
-  },
-  {
     name: "Toru Hiyama",
     role: "None",
     desc: "SimpleForm, Inc<br>None",

--- a/about/alumni/index.html
+++ b/about/alumni/index.html
@@ -58,8 +58,8 @@
                 </div>
 
                 <div class="card reveal member-card" style="transition-delay: 0.2s; background-color: #f8fafc; border: none;">
-                    <img src="https://avatars.githubusercontent.com/u/9821370" alt="pei 0804" class="member-photo">
-                    <h3>pei 0804</h3>
+                    <img src="https://avatars.githubusercontent.com/u/9821370" alt="pei0804" class="member-photo">
+                    <h3>pei0804</h3>
                     <p style="color: var(--text-light); font-weight: 500; font-size: 0.9rem; margin-bottom: 10px;">
                         📅 在籍期間: 2025
                     </p>

--- a/about/alumni/index.html
+++ b/about/alumni/index.html
@@ -56,6 +56,18 @@
                         数々のハンズオン資料を作成し、多くの初心者をSnowflakeの世界へ導きました。
                     </p>
                 </div>
+
+                <div class="card reveal member-card" style="transition-delay: 0.2s; background-color: #f8fafc; border: none;">
+                    <img src="https://avatars.githubusercontent.com/u/9821370" alt="pei 0804" class="member-photo">
+                    <h3>pei 0804</h3>
+                    <p style="color: var(--text-light); font-weight: 500; font-size: 0.9rem; margin-bottom: 10px;">
+                        📅 在籍期間: 2025
+                    </p>
+                    <p style="color: var(--primary); font-weight: 600; font-size: 0.9rem;">Former Data Strategy 担当</p>
+                    <p class="desc" style="font-size: 0.9rem; color: var(--text-light); margin-top: 10px;">
+                        イベント登壇や賑やかし役として、コミュニティを盛り上げてくださいました。
+                    </p>
+                </div>
             </div>
             
             <div class="reveal" style="text-align: center; margin-top: 60px;">


### PR DESCRIPTION
## Summary

- 現役 Mayors リスト（`about/aboutData.js`）から `pei 0804` エントリを削除
- 歴代の貢献者ページ（`about/alumni/index.html`）にカードを追加
  - 名前: `pei0804`
  - 在籍期間: 2025
  - 役割: Former Data Strategy 担当
  - 貢献: イベント登壇・賑やかし
  - 画像は GitHub アバター（`https://avatars.githubusercontent.com/u/9821370`）を直接参照

Closes #24

## Test plan

- [ ] `about/alumni/` をブラウザで開き、pei0804 のカードが Data Saburo / Cloud Shiro の後ろに表示されること
- [ ] GitHub アバターが正しく読み込まれていること
- [ ] `about/mayors/` から pei0804 が消えていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)