### PR TITLE
Preserve original 16:9 ratio of contents thumbnails on /en/

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -150,13 +150,14 @@
       }
       .content-thumb {
         width: 100%;
-        height: 180px;
+        aspect-ratio: 16 / 9;
         background: linear-gradient(135deg, var(--acc-blue) 0%, #ffffff 100%);
         display: flex;
         align-items: center;
         justify-content: center;
+        overflow: hidden;
       }
-      .content-thumb img { width: 100%; height: 100%; object-fit: cover; }
+      .content-thumb img { width: 100%; height: 100%; object-fit: contain; display: block; }
       .content-body { padding: 24px; display: flex; flex-direction: column; gap: 10px; flex: 1; }
       .content-type {
         display: inline-block;


### PR DESCRIPTION
Replace fixed height: 180px with aspect-ratio: 16 / 9 so card thumbs scale with card width. object-fit switched to contain so the original aspect is always shown without cropping.